### PR TITLE
Remove leading 'v' from META6.info

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name" : "Cookie::Baker",
   "source-url" : "git://github.com/tokuhirom/p6-Cookie-Baker.git",
-  "perl" : "v6",
+  "perl" : "6",
   "build-depends" : [ ],
   "provides" : {
     "Cookie::Baker" : "lib/Cookie/Baker.pm6"


### PR DESCRIPTION
It's a minor change, but when installing via Panda, I get this notice:

==> Fetching Cookie::Baker
Please remove leading 'v' from perl version in Cookie::Baker's meta info.

This silences the warning.
